### PR TITLE
Sliders sidebar scrollability

### DIFF
--- a/smap/public/index.html
+++ b/smap/public/index.html
@@ -95,7 +95,7 @@
                 <div id="statistics-sliders-header">
                     Statistic Settings:
                 </div>
-                <div id="statistics-sliders">
+                <div class="safari10_sliders" id="statistics-sliders">
                     <!-- This is the template for each statistic slider container, the only thing
                          that is unique is encapsulated in square brackets [[[]]] -->
                     <!--
@@ -113,12 +113,12 @@
                         <input class="statistic-slider" type="range" min="1" max="5" value="3" />
                         <div class="statistic-slider-metadata">&#9432;</div>
                         <div class="statistic-slider-tick-container">
-            							<p class="single-ticks-1">1</p>
-            							<p class="single-ticks-2">2</p>
-            							<p class="single-ticks-3">3</p>
-            							<p class="single-ticks-4">4</p>
-            							<p class="single-ticks-5">5</p>
-            						</div>
+                            <p class="single-ticks-1">1</p>
+                            <p class="single-ticks-2">2</p>
+                            <p class="single-ticks-3">3</p>
+                            <p class="single-ticks-4">4</p>
+                            <p class="single-ticks-5">5</p>
+                        </div>
                     </div>
                 </div>
 
@@ -126,7 +126,7 @@
                     Statistic Selection:
                 </div>
                 <!-- All of the other statistics that are not sliders -->
-                <div id="statistics-selector">
+                <div class="safari10_sliders" id="statistics-selector">
                     <!-- This is the template for each statistic selector container, the only thing
                          that is unique is encapsulated in square brackets [[[]]] -->
                     <!--

--- a/smap/public/stylesheets/style.css
+++ b/smap/public/stylesheets/style.css
@@ -285,6 +285,13 @@ Thumbs are hard to come by, but this site knows how to style them
     border-bottom-width: 0px;
     background-color: var(--secondary-color-light);
 }
+@media not all and (min-resolution:.001dpcm) {
+    @media {
+        .safari10_sliders {
+            max-height: 40vh;
+        }
+    }
+}
 
 /**************************/
 /***  Selector Styling  ***/
@@ -374,6 +381,14 @@ Thumbs are hard to come by, but this site knows how to style them
     border-top-width: 0px;
     border-bottom-width: 0px;
     background-color: var(--secondary-color-light);
+}
+@media not all and (min-resolution:.001dpcm) {
+    @media {
+        .safari10_sliders {
+            max-height: 45vh;
+            color: teal;
+        }
+    }
 }
 
 /*************************/
@@ -876,7 +891,7 @@ object {
 @media not all and (min-resolution:.001dpcm) {
     @media {
         .safari10 {
-            height: 90vh;
+            max-height: 90vh;
         }
     }
 }

--- a/smap/public/stylesheets/style.css
+++ b/smap/public/stylesheets/style.css
@@ -285,6 +285,11 @@ Thumbs are hard to come by, but this site knows how to style them
     border-bottom-width: 0px;
     background-color: var(--secondary-color-light);
 }
+/*
+* External citation: https://www.ryadel.com/en/css3-media-query-target-only-ie-ie6-ie11-firefox-chrome-safari-edge/
+* This @media section is the most commonly used way to specify styling for only certain conditions, including
+* the use of a specific browser.
+*/
 @media not all and (min-resolution:.001dpcm) {
     @media {
         .safari10_sliders {
@@ -382,6 +387,11 @@ Thumbs are hard to come by, but this site knows how to style them
     border-bottom-width: 0px;
     background-color: var(--secondary-color-light);
 }
+/*
+* External citation: https://www.ryadel.com/en/css3-media-query-target-only-ie-ie6-ie11-firefox-chrome-safari-edge/
+* This @media section is the most commonly used way to specify styling for only certain conditions, including
+* the use of a specific browser.
+*/
 @media not all and (min-resolution:.001dpcm) {
     @media {
         .safari10_sliders {

--- a/smap/public/stylesheets/style.css
+++ b/smap/public/stylesheets/style.css
@@ -386,7 +386,6 @@ Thumbs are hard to come by, but this site knows how to style them
     @media {
         .safari10_sliders {
             max-height: 45vh;
-            color: teal;
         }
     }
 }


### PR DESCRIPTION
The sidebar now scrolls instead of overflowing its container. Safari handles % sizes differently than other browsers...

Fixes issue #95 